### PR TITLE
fix: correct SavedVendor migration order (unbreak main's from-scratch migrate)

### DIFF
--- a/api/migrations/Version20260723025956.php
+++ b/api/migrations/Version20260723025956.php
@@ -10,7 +10,7 @@ use Doctrine\Migrations\AbstractMigration;
 /**
  * Auto-generated Migration: Please modify to your needs!
  */
-final class Version20260722223410 extends AbstractMigration
+final class Version20260723025956 extends AbstractMigration
 {
     public function getDescription(): string
     {


### PR DESCRIPTION
## Urgent — main's DB can't rebuild from scratch
When #44 merged, its `Version20260722223410` (SavedVendor) landed alongside #45's squashed baseline `Version20260722231706`. Because `223410 < 231706`, a from-scratch `doctrine:migrations:migrate` runs the SavedVendor migration **first** — before the baseline creates `user`/`vendor_profile` — and dies with *relation "user" does not exist*. That breaks CI's test-DB creation and any fresh deploy.

## Fix
Replace `223410` with `Version20260723025956`, which sorts after the baseline and just creates `saved_vendor`. No schema change to any other table.

## Verified
From-scratch on a fresh DB: `migrate` → **Successfully migrated to Version20260723025956**, `schema:validate` → **in sync**.

Merge this right after — the other open PRs (#46/#47/#48) rebase onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)